### PR TITLE
Compute final opacity or color in vertex-shader

### DIFF
--- a/src/shaders/circle.fragment.glsl
+++ b/src/shaders/circle.fragment.glsl
@@ -1,21 +1,16 @@
 varying vec3 v_data;
 
-#pragma mapbox: define highp vec4 color
+varying mediump vec4 v_color;
+varying mediump vec4 v_stroke_color;
+
 #pragma mapbox: define mediump float radius
 #pragma mapbox: define lowp float blur
-#pragma mapbox: define lowp float opacity
-#pragma mapbox: define highp vec4 stroke_color
 #pragma mapbox: define mediump float stroke_width
-#pragma mapbox: define lowp float stroke_opacity
 
 void main() {
-    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize mediump float radius
     #pragma mapbox: initialize lowp float blur
-    #pragma mapbox: initialize lowp float opacity
-    #pragma mapbox: initialize highp vec4 stroke_color
     #pragma mapbox: initialize mediump float stroke_width
-    #pragma mapbox: initialize lowp float stroke_opacity
 
     vec2 extrude = v_data.xy;
     float extrude_length = length(extrude);
@@ -31,7 +26,7 @@ void main() {
         extrude_length - radius / (radius + stroke_width)
     );
 
-    gl_FragColor = opacity_t * mix(color * opacity, stroke_color * stroke_opacity, color_t);
+    gl_FragColor = opacity_t * mix(v_color, v_stroke_color, color_t);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/circle.vertex.glsl
+++ b/src/shaders/circle.vertex.glsl
@@ -9,6 +9,9 @@ attribute vec2 a_pos;
 
 varying vec3 v_data;
 
+varying mediump vec4 v_color;
+varying mediump vec4 v_stroke_color;
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define mediump float radius
 #pragma mapbox: define lowp float blur
@@ -61,4 +64,7 @@ void main(void) {
     lowp float antialiasblur = 1.0 / u_device_pixel_ratio / (radius + stroke_width);
 
     v_data = vec3(extrude.x, extrude.y, antialiasblur);
+
+    v_color = color * opacity;
+    v_stroke_color = stroke_color * stroke_opacity;
 }

--- a/src/shaders/fill.fragment.glsl
+++ b/src/shaders/fill.fragment.glsl
@@ -1,11 +1,7 @@
-#pragma mapbox: define highp vec4 color
-#pragma mapbox: define lowp float opacity
+varying mediump vec4 v_color;
 
 void main() {
-    #pragma mapbox: initialize highp vec4 color
-    #pragma mapbox: initialize lowp float opacity
-
-    gl_FragColor = color * opacity;
+    gl_FragColor = v_color;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/fill.vertex.glsl
+++ b/src/shaders/fill.vertex.glsl
@@ -2,6 +2,8 @@ attribute vec2 a_pos;
 
 uniform mat4 u_matrix;
 
+varying mediump vec4 v_color;
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float opacity
 
@@ -10,4 +12,6 @@ void main() {
     #pragma mapbox: initialize lowp float opacity
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
+
+    v_color = color * opacity;
 }

--- a/src/shaders/fill_outline.fragment.glsl
+++ b/src/shaders/fill_outline.fragment.glsl
@@ -1,15 +1,11 @@
 varying vec2 v_pos;
 
-#pragma mapbox: define highp vec4 outline_color
-#pragma mapbox: define lowp float opacity
+varying mediump vec4 v_outline_color;
 
 void main() {
-    #pragma mapbox: initialize highp vec4 outline_color
-    #pragma mapbox: initialize lowp float opacity
-
     float dist = length(v_pos - gl_FragCoord.xy);
     float alpha = 1.0 - smoothstep(0.0, 1.0, dist);
-    gl_FragColor = outline_color * (alpha * opacity);
+    gl_FragColor = v_outline_color * alpha;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/fill_outline.vertex.glsl
+++ b/src/shaders/fill_outline.vertex.glsl
@@ -5,12 +5,16 @@ uniform vec2 u_world;
 
 varying vec2 v_pos;
 
+varying lowp vec4 v_outline_color;
+
 #pragma mapbox: define highp vec4 outline_color
 #pragma mapbox: define lowp float opacity
 
 void main() {
     #pragma mapbox: initialize highp vec4 outline_color
     #pragma mapbox: initialize lowp float opacity
+
+    v_outline_color = outline_color * opacity;
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;

--- a/src/shaders/fill_outline.vertex.glsl
+++ b/src/shaders/fill_outline.vertex.glsl
@@ -14,4 +14,6 @@ void main() {
 
     gl_Position = u_matrix * vec4(a_pos, 0, 1);
     v_pos = (gl_Position.xy / gl_Position.w + 1.0) / 2.0 * u_world;
+
+    v_outline_color = outline_color * opacity;
 }

--- a/src/shaders/line.fragment.glsl
+++ b/src/shaders/line.fragment.glsl
@@ -4,14 +4,12 @@ varying vec2 v_width2;
 varying vec2 v_normal;
 varying float v_gamma_scale;
 
-#pragma mapbox: define highp vec4 color
+varying mediump vec4 v_color;
+
 #pragma mapbox: define lowp float blur
-#pragma mapbox: define lowp float opacity
 
 void main() {
-    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
-    #pragma mapbox: initialize lowp float opacity
 
     // Calculate the distance of the pixel from the line in pixels.
     float dist = length(v_normal) * v_width2.s;
@@ -22,7 +20,7 @@ void main() {
     float blur2 = (blur + 1.0 / u_device_pixel_ratio) * v_gamma_scale;
     float alpha = clamp(min(dist - (v_width2.t - blur2), v_width2.s - dist) / blur2, 0.0, 1.0);
 
-    gl_FragColor = color * (alpha * opacity);
+    gl_FragColor = v_color * alpha;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/line.vertex.glsl
+++ b/src/shaders/line.vertex.glsl
@@ -19,6 +19,8 @@ varying vec2 v_width2;
 varying float v_gamma_scale;
 varying highp float v_linesofar;
 
+varying mediump vec4 v_color;
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
@@ -82,4 +84,6 @@ void main() {
     v_gamma_scale = extrude_length_without_perspective / extrude_length_with_perspective;
 
     v_width2 = vec2(outset, inset);
+
+    v_color = color * opacity;
 }

--- a/src/shaders/line_sdf.fragment.glsl
+++ b/src/shaders/line_sdf.fragment.glsl
@@ -10,16 +10,14 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
-#pragma mapbox: define highp vec4 color
+varying mediump vec4 v_color;
+
 #pragma mapbox: define lowp float blur
-#pragma mapbox: define lowp float opacity
 #pragma mapbox: define mediump float width
 #pragma mapbox: define lowp float floorwidth
 
 void main() {
-    #pragma mapbox: initialize highp vec4 color
     #pragma mapbox: initialize lowp float blur
-    #pragma mapbox: initialize lowp float opacity
     #pragma mapbox: initialize mediump float width
     #pragma mapbox: initialize lowp float floorwidth
 
@@ -37,7 +35,7 @@ void main() {
     float sdfdist = mix(sdfdist_a, sdfdist_b, u_mix);
     alpha *= smoothstep(0.5 - u_sdfgamma / floorwidth, 0.5 + u_sdfgamma / floorwidth, sdfdist);
 
-    gl_FragColor = color * (alpha * opacity);
+    gl_FragColor = v_color * alpha;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/line_sdf.vertex.glsl
+++ b/src/shaders/line_sdf.vertex.glsl
@@ -28,6 +28,8 @@ varying vec2 v_tex_a;
 varying vec2 v_tex_b;
 varying float v_gamma_scale;
 
+varying mediump vec4 v_color;
+
 #pragma mapbox: define highp vec4 color
 #pragma mapbox: define lowp float blur
 #pragma mapbox: define lowp float opacity
@@ -95,4 +97,6 @@ void main() {
     v_tex_b = vec2(a_linesofar * u_patternscale_b.x / floorwidth, normal.y * u_patternscale_b.y + u_tex_y_b);
 
     v_width2 = vec2(outset, inset);
+
+    v_color = color * opacity;
 }

--- a/src/shaders/symbol_icon.fragment.glsl
+++ b/src/shaders/symbol_icon.fragment.glsl
@@ -3,13 +3,10 @@ uniform sampler2D u_texture;
 varying vec2 v_tex;
 varying float v_fade_opacity;
 
-#pragma mapbox: define lowp float opacity
+varying lowp float v_combined_opacity;
 
 void main() {
-    #pragma mapbox: initialize lowp float opacity
-
-    lowp float alpha = opacity * v_fade_opacity;
-    gl_FragColor = texture2D(u_texture, v_tex) * alpha;
+    gl_FragColor = texture2D(u_texture, v_tex) * v_combined_opacity;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/symbol_icon.vertex.glsl
+++ b/src/shaders/symbol_icon.vertex.glsl
@@ -26,7 +26,8 @@ uniform bool u_pitch_with_map;
 uniform vec2 u_texsize;
 
 varying vec2 v_tex;
-varying float v_fade_opacity;
+
+varying lowp float v_combined_opacity;
 
 #pragma mapbox: define lowp float opacity
 
@@ -90,5 +91,7 @@ void main() {
     v_tex = a_tex / u_texsize;
     vec2 fade_opacity = unpack_opacity(a_fade_opacity);
     float fade_change = fade_opacity[1] > 0.5 ? u_fade_change : -u_fade_change;
-    v_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+    float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
+
+    v_combined_opacity = opacity * interpolated_fade_opacity;
 }

--- a/src/shaders/symbol_sdf.fragment.glsl
+++ b/src/shaders/symbol_sdf.fragment.glsl
@@ -11,14 +11,12 @@ varying vec3 v_data1;
 
 #pragma mapbox: define highp vec4 fill_color
 #pragma mapbox: define highp vec4 halo_color
-#pragma mapbox: define lowp float opacity
 #pragma mapbox: define lowp float halo_width
 #pragma mapbox: define lowp float halo_blur
 
 void main() {
     #pragma mapbox: initialize highp vec4 fill_color
     #pragma mapbox: initialize highp vec4 halo_color
-    #pragma mapbox: initialize lowp float opacity
     #pragma mapbox: initialize lowp float halo_width
     #pragma mapbox: initialize lowp float halo_blur
 
@@ -27,7 +25,7 @@ void main() {
     vec2 tex = v_data0.xy;
     float gamma_scale = v_data1.x;
     float size = v_data1.y;
-    float fade_opacity = v_data1[2];
+    lowp float combined_opacity = v_data1[2];
 
     float fontScale = u_is_text ? size / 24.0 : size;
 
@@ -44,7 +42,7 @@ void main() {
     highp float gamma_scaled = gamma * gamma_scale;
     highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
 
-    gl_FragColor = color * (alpha * opacity * fade_opacity);
+    gl_FragColor = color * (alpha * combined_opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/symbol_sdf.fragment.glsl
+++ b/src/shaders/symbol_sdf.fragment.glsl
@@ -7,16 +7,15 @@ uniform lowp float u_device_pixel_ratio;
 uniform bool u_is_text;
 
 varying vec2 v_data0;
-varying vec3 v_data1;
+varying vec2 v_data1;
 
-#pragma mapbox: define highp vec4 fill_color
-#pragma mapbox: define highp vec4 halo_color
+varying lowp vec4 v_fill_color;
+varying lowp vec4 v_halo_color;
+
 #pragma mapbox: define lowp float halo_width
 #pragma mapbox: define lowp float halo_blur
 
 void main() {
-    #pragma mapbox: initialize highp vec4 fill_color
-    #pragma mapbox: initialize highp vec4 halo_color
     #pragma mapbox: initialize lowp float halo_width
     #pragma mapbox: initialize lowp float halo_blur
 
@@ -25,15 +24,14 @@ void main() {
     vec2 tex = v_data0.xy;
     float gamma_scale = v_data1.x;
     float size = v_data1.y;
-    lowp float combined_opacity = v_data1[2];
 
     float fontScale = u_is_text ? size / 24.0 : size;
 
-    lowp vec4 color = fill_color;
+    lowp vec4 color = v_fill_color;
     highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
     lowp float buff = (256.0 - 64.0) / 256.0;
     if (u_is_halo) {
-        color = halo_color;
+        color = v_halo_color;
         gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
         buff = (6.0 - halo_width / fontScale) / SDF_PX;
     }
@@ -42,7 +40,7 @@ void main() {
     highp float gamma_scaled = gamma * gamma_scale;
     highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
 
-    gl_FragColor = color * (alpha * combined_opacity);
+    gl_FragColor = color * alpha;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -30,7 +30,10 @@ uniform float u_fade_change;
 uniform vec2 u_texsize;
 
 varying vec2 v_data0;
-varying vec3 v_data1;
+varying vec2 v_data1;
+
+varying lowp vec4 v_fill_color;
+varying lowp vec4 v_halo_color;
 
 #pragma mapbox: define highp vec4 fill_color
 #pragma mapbox: define highp vec4 halo_color
@@ -111,5 +114,9 @@ void main() {
     float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
 
     v_data0 = a_tex / u_texsize;
-    v_data1 = vec3(gamma_scale, size, opacity * interpolated_fade_opacity);
+    v_data1 = vec2(gamma_scale, size);
+
+    float combined_opacity = opacity * interpolated_fade_opacity;
+    v_fill_color = fill_color * combined_opacity;
+    v_halo_color = halo_color * combined_opacity;
 }

--- a/src/shaders/symbol_sdf.vertex.glsl
+++ b/src/shaders/symbol_sdf.vertex.glsl
@@ -111,5 +111,5 @@ void main() {
     float interpolated_fade_opacity = max(0.0, min(1.0, fade_opacity[0] + fade_change));
 
     v_data0 = a_tex / u_texsize;
-    v_data1 = vec3(gamma_scale, size, interpolated_fade_opacity);
+    v_data1 = vec3(gamma_scale, size, opacity * interpolated_fade_opacity);
 }

--- a/src/shaders/symbol_text_and_icon.fragment.glsl
+++ b/src/shaders/symbol_text_and_icon.fragment.glsl
@@ -14,23 +14,20 @@ varying vec4 v_data1;
 
 #pragma mapbox: define highp vec4 fill_color
 #pragma mapbox: define highp vec4 halo_color
-#pragma mapbox: define lowp float opacity
 #pragma mapbox: define lowp float halo_width
 #pragma mapbox: define lowp float halo_blur
 
 void main() {
     #pragma mapbox: initialize highp vec4 fill_color
     #pragma mapbox: initialize highp vec4 halo_color
-    #pragma mapbox: initialize lowp float opacity
     #pragma mapbox: initialize lowp float halo_width
     #pragma mapbox: initialize lowp float halo_blur
 
-    float fade_opacity = v_data1[2];
+    lowp float combined_opacity = v_data1[2];
 
     if (v_data1.w == ICON) {
         vec2 tex_icon = v_data0.zw;
-        lowp float alpha = opacity * fade_opacity;
-        gl_FragColor = texture2D(u_texture_icon, tex_icon) * alpha;
+        gl_FragColor = texture2D(u_texture_icon, tex_icon) * combined_opacity;
 
 #ifdef OVERDRAW_INSPECTOR
         gl_FragColor = vec4(1.0);
@@ -60,7 +57,7 @@ void main() {
     highp float gamma_scaled = gamma * gamma_scale;
     highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
 
-    gl_FragColor = color * (alpha * opacity * fade_opacity);
+    gl_FragColor = color * (alpha * combined_opacity);
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/symbol_text_and_icon.fragment.glsl
+++ b/src/shaders/symbol_text_and_icon.fragment.glsl
@@ -10,22 +10,19 @@ uniform highp float u_gamma_scale;
 uniform lowp float u_device_pixel_ratio;
 
 varying vec4 v_data0;
-varying vec4 v_data1;
+varying vec3 v_data1;
 
-#pragma mapbox: define highp vec4 fill_color
-#pragma mapbox: define highp vec4 halo_color
+varying lowp vec4 v_fill_color;
+varying lowp vec4 v_halo_color;
+
 #pragma mapbox: define lowp float halo_width
 #pragma mapbox: define lowp float halo_blur
 
 void main() {
-    #pragma mapbox: initialize highp vec4 fill_color
-    #pragma mapbox: initialize highp vec4 halo_color
     #pragma mapbox: initialize lowp float halo_width
     #pragma mapbox: initialize lowp float halo_blur
 
-    lowp float combined_opacity = v_data1[2];
-
-    if (v_data1.w == ICON) {
+    if (v_data1.z == ICON) {
         vec2 tex_icon = v_data0.zw;
         gl_FragColor = texture2D(u_texture_icon, tex_icon) * combined_opacity;
 
@@ -44,11 +41,11 @@ void main() {
 
     float fontScale = size / 24.0;
 
-    lowp vec4 color = fill_color;
+    lowp vec4 color = v_fill_color;
     highp float gamma = EDGE_GAMMA / (fontScale * u_gamma_scale);
     lowp float buff = (256.0 - 64.0) / 256.0;
     if (u_is_halo) {
-        color = halo_color;
+        color = v_halo_color;
         gamma = (halo_blur * 1.19 / SDF_PX + EDGE_GAMMA) / (fontScale * u_gamma_scale);
         buff = (6.0 - halo_width / fontScale) / SDF_PX;
     }
@@ -57,7 +54,7 @@ void main() {
     highp float gamma_scaled = gamma * gamma_scale;
     highp float alpha = smoothstep(buff - gamma_scaled, buff + gamma_scaled, dist);
 
-    gl_FragColor = color * (alpha * combined_opacity);
+    gl_FragColor = color * alpha;
 
 #ifdef OVERDRAW_INSPECTOR
     gl_FragColor = vec4(1.0);

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -112,5 +112,5 @@ void main() {
 
     v_data0.xy = a_tex / u_texsize;
     v_data0.zw = a_tex / u_texsize_icon;
-    v_data1 = vec4(gamma_scale, size, interpolated_fade_opacity, is_sdf);
+    v_data1 = vec4(gamma_scale, size, opacity * interpolated_fade_opacity, is_sdf);
 }

--- a/src/shaders/symbol_text_and_icon.vertex.glsl
+++ b/src/shaders/symbol_text_and_icon.vertex.glsl
@@ -30,7 +30,10 @@ uniform vec2 u_texsize;
 uniform vec2 u_texsize_icon;
 
 varying vec4 v_data0;
-varying vec4 v_data1;
+varying vec3 v_data1;
+
+varying lowp vec4 v_fill_color;
+varying lowp vec4 v_halo_color;
 
 #pragma mapbox: define highp vec4 fill_color
 #pragma mapbox: define highp vec4 halo_color
@@ -112,5 +115,9 @@ void main() {
 
     v_data0.xy = a_tex / u_texsize;
     v_data0.zw = a_tex / u_texsize_icon;
-    v_data1 = vec4(gamma_scale, size, opacity * interpolated_fade_opacity, is_sdf);
+    v_data1 = vec3(gamma_scale, size, is_sdf);
+
+    float combined_opacity = opacity * interpolated_fade_opacity;
+    v_fill_color = fill_color * combined_opacity;
+    v_halo_color = halo_color * combined_opacity;
 }


### PR DESCRIPTION
Basically an attempt to move more logic from fragment shaders into vertex-shaders.

This should save some cycles (thereby power) on lower-end GPUs.
However, more importantly, this will allow potential future optimizations (in follow-up PRs):

- Move fully transparent features off-screen in vertex-shader, to avoid fragment shader execution entirely. We use mapbox in a product where we have hundreds of symbols, and we toggle their opacity using feature-states to avoid redoing placement on the CPU (which is slower than the opacity-buffer update).
- Pre-compute the `color * opacity` on the CPU; although I expect that most shader-optimizers will catch this.

Unfortunately, this change could also make performance worse, due to how `#pragma mapbox` works:

|                        | opacity is uniform | opacity is attribute |
|------------------------|:------------------:|:--------------------:|
| **color is uniform**   | (1) worse          | (2) better           |
| **color is attribute** | (2) better         | (3) better           |

1.  Old code: shader-compiler will likely precompute `color * opacity` on the CPU, and load it from the uniform registers.
    New code: shader-compiler will potentially optimize on the vertex side, but link-optimization is required to optimize on the fragment side; varyings potentially costs a bit of performance.
2.  Old code: shader would compute the color per-fragment.
    New code: shader can compute color per-vertex; and interpolate across fragment using hardware.
3.  Old code: shader would compute the color per-fragment.
    New code: shader can compute color per-vertex; and interpolate across fragment using hardware.

So there's still a bunch of room for improvements.


**Will move upstream when I've confirmed that it's faster.**